### PR TITLE
Add test for stream upload

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -257,7 +257,7 @@ export default class Container extends Syncable {
       method: 'POST',
       url: `${this.url()}/files`,
       qs: { path },
-      json: false,
+      json: true,
       headers: {
         'X-LXD-type': 'file',
       }
@@ -267,7 +267,7 @@ export default class Container extends Syncable {
       stream.on('error', reject);
       stream.on('end', () => {
         stream.destroy();
-        resolve();
+        resolve(request);
       });
 
       stream.pipe(request);


### PR DESCRIPTION
- Wrote test for stream upload
- Separate string_upload in config from upload
- Upload now returns the response from LXD as JSON instead of undefined (because of empty Promise return)