### PR TITLE
Publish containers

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -7,6 +7,7 @@ import WebSocket from 'ws';
 
 import { AsyncOperation, Operation } from './operation';
 import Container from './container';
+import Image from './image';
 import Pool from './pool';
 import { map_series, wait_for_socket_open } from './util';
 
@@ -79,6 +80,15 @@ export default class Client {
   // Get LXD container representation
   get_container(name) {
     return new Container(this, name);
+  }
+
+  get_image(fingerprint = null) {
+    return new Image(this, fingerprint);
+  }
+
+  // Get list of images
+  async list_images() {
+    return this.operation().get('/images');
   }
 
   // Get list of containers

--- a/src/container.js
+++ b/src/container.js
@@ -65,7 +65,7 @@ export default class Container extends Syncable {
     let args = ['/instances', this.config];
 
     if(typeof this.target !== 'undefined') {
-      args.push({ target: this.target });    
+      args.push({ target: this.target });
 
     }
 
@@ -125,8 +125,8 @@ export default class Container extends Syncable {
   }
 
   // Publish container as image
-  async publish() {
-    return this.client.get_image().from_container(this).set_aliases([{ name: this.name() }]).create();
+  async publish(aliases = [{ name: this.name() }]) {
+    return this.client.get_image().from_container(this).set_aliases(aliases).create();
   }
 
   // Remove this container from LXD backend

--- a/src/container.js
+++ b/src/container.js
@@ -65,7 +65,8 @@ export default class Container extends Syncable {
     let args = ['/instances', this.config];
 
     if(typeof this.target !== 'undefined') {
-      args.push({ target: this.target });
+      args.push({ target: this.target });    
+
     }
 
     // Create container
@@ -121,6 +122,20 @@ export default class Container extends Syncable {
     } else {
       return this;
     }
+  }
+
+  // Publish container as image
+  async publish() {
+    let body = {
+      aliases: [ { name: this.name() } ],
+      public: false,
+      source: {
+        type: 'container',
+        name: this.name(),
+      },
+    };
+
+    return this.client.async_operation().post('/images', body);
   }
 
   // Remove this container from LXD backend

--- a/src/container.js
+++ b/src/container.js
@@ -126,16 +126,7 @@ export default class Container extends Syncable {
 
   // Publish container as image
   async publish() {
-    let body = {
-      aliases: [ { name: this.name() } ],
-      public: false,
-      source: {
-        type: 'container',
-        name: this.name(),
-      },
-    };
-
-    return this.client.async_operation().post('/images', body);
+    return this.client.get_image().from_container(this).set_aliases([{ name: this.name() }]).create();
   }
 
   // Remove this container from LXD backend

--- a/src/image.js
+++ b/src/image.js
@@ -1,0 +1,100 @@
+
+import Syncable from './syncable';
+
+export default class Image extends Syncable {
+  constructor(client, fingerprint = null) {
+    super(client, fingerprint);
+  }
+
+  // Overwrite name method since images use fingerprint
+  name() {
+    return this.config.fingerprint;
+  }
+
+  /**
+   * Find image by alias
+   * - primarily intented for tests
+   */
+  async by_alias(alias) {
+    try {
+      let res = await this.client.operation().get(`/images/aliases/${alias}`)
+      this.config.fingerprint = res.target;
+    } catch(err) {
+      throw err;
+    }
+
+    return this.load();
+  }
+
+  set_default_config(fingerprint = null) {
+    this.config = {
+      fingerprint: fingerprint,
+      profiles: [ 'default' ], // Note: profiles can only be set AFTER image is created (https://discuss.linuxcontainers.org/t/container-config-sticky-with-image/5782)
+      public: false,
+      source: {},
+    };
+    return this.set_synced(false);
+  }
+
+  url() {
+    return `/images/${this.name()}`;
+  }
+
+  /**
+   * Publish image from container
+   */
+  from_container(container) {
+    this.config.source = {
+      name: container.name(),
+      type: 'container',
+    };
+
+    return this;
+  }
+
+  set_aliases(aliases) {
+    this.config.aliases = aliases;
+    return this;
+  }
+
+  /**
+   * Note: profiles can only be set AFTER image is created (https://discuss.linuxcontainers.org/t/container-config-sticky-with-image/5782)
+   * @important Call update() on this image to update
+   */
+  set_profiles(profiles) {
+    if(!this.is_synced) {
+      throw new Error('Profiles can only be set after image creation');
+    }
+
+    this.config.profiles = profiles;
+    this.is_synced = false;
+    return this;
+  }
+
+  async create() {
+    try {
+      let res = await this.client.async_operation().post('/images', this.config)
+
+      // The fingerprint in the initial response lives in `metadata` whereas eventually it will be in the image object
+      // Set it here for load method to work
+      this.config.fingerprint = res.metadata.fingerprint;
+    } catch(err) {
+      throw err;
+    }
+
+    return this.load();
+  }
+
+  async update() {
+    let response = await this.client.operation().put(this.url(), this.config);
+    return this.load();
+  }
+
+  async destroy() {
+    await this.client.async_operation().delete(this.url());
+    await this.unload();
+
+    return this;
+  }
+
+}

--- a/src/image.js
+++ b/src/image.js
@@ -16,12 +16,8 @@ export default class Image extends Syncable {
    * - primarily intented for tests
    */
   async by_alias(alias) {
-    try {
-      let res = await this.client.operation().get(`/images/aliases/${alias}`)
-      this.config.fingerprint = res.target;
-    } catch(err) {
-      throw err;
-    }
+    let res = await this.client.operation().get(`/images/aliases/${alias}`)
+    this.config.fingerprint = res.target;
 
     return this.load();
   }

--- a/src/image.js
+++ b/src/image.js
@@ -48,6 +48,8 @@ export default class Image extends Syncable {
     return this;
   }
 
+  // @TODO this only works on initial create
+  // to make this work on update it would be better to give aliases it's own interface
   set_aliases(aliases) {
     this.config.aliases = aliases;
     return this;

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 import Client from './client';
 import Container from './container';
 import Volume from './volume';
+import Image from './image';
 import Snapshot from './snapshot';
 import Backup from './backup';
 
@@ -9,6 +10,7 @@ export {
   Client as LXD,
   Container,
   Volume,
+  Image,
   Snapshot,
   Backup,
 }

--- a/test/index.js
+++ b/test/index.js
@@ -625,7 +625,29 @@ describe('Container', () => {
     })
   })
 
-  describe('delete()', () => {
+  describe('publish()', () => {
+    let image;
+
+    after(() => {
+      // @TODO - tmp, make image deletion part of package
+      return lxd.async_operation().delete(`/images/${image.metadata.fingerprint}`);
+    })
+    it('does not publish running container', () => {
+      return container.publish().should.eventually.be.rejected;
+    })
+
+    it('publishes container as image', async function () {
+      this.timeout(30000);
+      await container.stop();
+      image = await container.publish();
+
+      image.status_code.should.equal(200);
+    })
+  })
+
+  describe('destroy()', () => {
+    before(() => container.start());
+
     it('does not delete running container', () => {
       container.destroy().should.be.rejected;
     });

--- a/test/index.js
+++ b/test/index.js
@@ -407,7 +407,8 @@ describe('Container', () => {
   })
 
   describe('create()', () => {
-    before(() => {
+    before(function () {
+      this.timeout(30000);
       return container
         .mount(volume, '/test', 'test')
         .set_environment_variable(config.container.variable.key, config.container.variable.value)
@@ -658,6 +659,8 @@ describe('Container', () => {
       image = await container.publish();
 
       image.should.be.instanceOf(Image);
+      image.is_synced.should.equal(true);
+      image.config.aliases.should.deep.include.members([{ name: 'test', description: '' }]);
     })
   })
 


### PR DESCRIPTION
Implemented Image class for interacting with LXD images.

It is implemented with our use in mind:
1) it should be easy to publish containers (I want to be able to just do `container.publish()`)
2) it should be possible to destroy images (either by passing fingerprint or alias)

*Image profiles*
By design it is not possible to publish a container with persistent profiles. So one needs to update an image to add additional profiles (see also: https://discuss.linuxcontainers.org/t/container-config-sticky-with-image/5782)